### PR TITLE
Fix for zig master

### DIFF
--- a/zig/neotest-runner.zig
+++ b/zig/neotest-runner.zig
@@ -73,7 +73,7 @@ pub fn main() !void {
             else => {
                 fail_count += 1;
                 if (@errorReturnTrace()) |stack_trace| {
-                    var last_frame_index: usize = @min(stack_trace.index, stack_trace.instruction_addresses.len) - 1;
+                    const last_frame_index = @min(stack_trace.index, stack_trace.instruction_addresses.len) - 1;
                     const return_address = stack_trace.instruction_addresses[last_frame_index];
                     const address = return_address - 1;
                     const module = try debug_info.getModuleForAddress(address);


### PR DESCRIPTION
Zig compiler now checks if a local variable is mutated so that variable needs to be const.
On a side note I don't understand why there is this check at the end 
```zig
    if (passed_count != 1 or skip_count != 1 or fail_count != 1) {
        std.process.exit(1);
    }
```
I think `or`s should be replaced with `and`s otherwise the process will always exit with 1.