### PR TITLE
fix: 0.9.5 compatibility

### DIFF
--- a/lua/neotest-zig/init.lua
+++ b/lua/neotest-zig/init.lua
@@ -440,7 +440,7 @@ function M.results(spec, _, tree)
         end
 
         local test_results_file_path = vim.fs.normalize(
-            spec.context.test_results_dir_path .. test_results_file_name
+            spec.context.test_results_dir_path .. "/" .. test_results_file_name
         )
 
         log.trace("Trying to open results file", test_results_file_path)

--- a/lua/neotest-zig/init.lua
+++ b/lua/neotest-zig/init.lua
@@ -439,7 +439,9 @@ function M.results(spec, _, tree)
             goto continue
         end
 
-        local test_results_file_path = vim.fs.joinpath(spec.context.test_results_dir_path, test_results_file_name)
+        local test_results_file_path = vim.fs.normalize(
+            spec.context.test_results_dir_path .. test_results_file_name
+        )
 
         log.trace("Trying to open results file", test_results_file_path)
         local success, test_results_json = pcall(lib.files.read, test_results_file_path)

--- a/lua/neotest-zig/log.lua
+++ b/lua/neotest-zig/log.lua
@@ -32,7 +32,7 @@ local function notify(msg, level)
     end
 end
 
-local logfilename = vim.fs.joinpath(vim.fn.stdpath('log'), 'neotest-zig.log')
+local logfilename = vim.fs.normalize(vim.fn.stdpath('log') .. '/' .. 'neotest-zig.log')
 
 vim.fn.mkdir(vim.fn.stdpath('log'), 'p')
 


### PR DESCRIPTION
Changed uses of `vim.fs.joinpath` to `vim.fs.normalize`. Addresses https://github.com/lawrence-laz/neotest-zig/issues/10. 