### PR TITLE
fix: Slow project root detection due to glob

### DIFF
--- a/lua/neotest-zig/init.lua
+++ b/lua/neotest-zig/init.lua
@@ -70,9 +70,9 @@ function M.match_root_pattern(...)
     end
 end
 
-M.root = M.match_root_pattern(
-    "**/*.zig" -- Search for zig files in current directory.
-)
+---Find the project root directory given a current directory to work from.
+---Should no root be found, the adapter can still be used in a non-project context if a test file matches.
+M.root = M.match_root_pattern("build.zig")
 
 M.filter_dir = function(name, rel_path, root)
     log.trace("Entered filter_dir with", name, rel_path, root);


### PR DESCRIPTION
We used to have `**/*.zig` as a glob pattern to detect project's root. This is quite slow for large non-zig projects though, because the search goes through all files to verify that the project does not contain any `.zig` files.

Having just `build.zig` as a prject root pattern should be enough though, because even the folder does not contain a `build.zig` file, the individiaul files/buffers are tested against all adapters by neotest.

Resolves #14