### PR TITLE
Debug improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ return {
 	config = function()
 		require("neotest").setup({
 			adapters = {
-                -- Registration
+				-- Registration
 				require("neotest-zig")({
-                    dap = {
-                        adapter = "lldb",
-                    }
-                }),
+					dap = {
+						adapter = "lldb",
+					}
+				}),
 			}
 		})
 	end

--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ return {
 	config = function()
 		require("neotest").setup({
 			adapters = {
-				require("neotest-zig"), -- Registration
+                -- Registration
+				require("neotest-zig")({
+                    dap = {
+                        adapter = "lldb",
+                    }
+                }),
 			}
 		})
 	end

--- a/lua/neotest-zig/init.lua
+++ b/lua/neotest-zig/init.lua
@@ -225,9 +225,6 @@ function M._build_spec_with_buildfile(args, build_file_path)
     log.debug("Successfully wrote test input into", neotest_input_path)
 
     local neotest_results_path = M._get_temp_file_path()
-    local context = {
-        test_results_dir_path = neotest_results_path,
-    }
 
     vim.loop.fs_mkdir(neotest_results_path, 493) -- Ensure tests results dir before running tests.
     local this_script_path = vim.fs.normalize(debug.getinfo(1).source:sub(2))
@@ -244,7 +241,11 @@ function M._build_spec_with_buildfile(args, build_file_path)
         log.error("Could not copy from", source_neotest_build_file_path, "to", target_neotest_build_file_path)
         return
     end
-    context.temp_neotest_build_file_path = target_neotest_build_file_path
+
+    local context = {
+        temp_neotest_build_file_path = target_neotest_build_file_path,
+        test_results_dir_path = neotest_results_path,
+    }
 
     -- Test runner logs have a separate directory, because
     -- Zig may launch multiple processes, where each process

--- a/lua/neotest-zig/init.lua
+++ b/lua/neotest-zig/init.lua
@@ -239,14 +239,12 @@ function M._build_spec_with_buildfile(args, build_file_path)
     local build_file_dir_path = build_file_path:match("(.*[/\\])")
     local target_neotest_build_file_path = build_file_dir_path .. "neotest_build.zig";
 
-    if vim.fn.filereadable(target_neotest_build_file_path) == 0 then
-        local success, errmsg = vim.loop.fs_copyfile(source_neotest_build_file_path, target_neotest_build_file_path)
-        if not success then
-            log.error("Could not copy from", source_neotest_build_file_path, "to", target_neotest_build_file_path)
-            return
-        end
-        context.temp_neotest_build_file_path = target_neotest_build_file_path
+    local success, errmsg = vim.loop.fs_copyfile(source_neotest_build_file_path, target_neotest_build_file_path)
+    if not success then
+        log.error("Could not copy from", source_neotest_build_file_path, "to", target_neotest_build_file_path)
+        return
     end
+    context.temp_neotest_build_file_path = target_neotest_build_file_path
 
     -- Test runner logs have a separate directory, because
     -- Zig may launch multiple processes, where each process

--- a/lua/neotest-zig/init.lua
+++ b/lua/neotest-zig/init.lua
@@ -269,17 +269,8 @@ function M._build_spec_with_buildfile(args, build_file_path)
     }
 
     if (args.strategy == "dap") then
-        local temp_neotest_runner_file_path = build_file_dir_path .. "/neotest_runner.zig"
-        if vim.fn.filereadable(temp_neotest_runner_file_path) == 0 then
-            local runner_copy_success, _ = vim.loop.fs_copyfile(test_runner_path, temp_neotest_runner_file_path)
-            if not runner_copy_success then
-                log.error("Could not copy from", test_runner_path, "to", temp_neotest_runner_file_path)
-                return
-            end
-            run_spec.context.temp_neotest_runner_file_path = temp_neotest_runner_file_path
-        end
         local future = nio.control.future()
-        build_async(target_neotest_build_file_path, "neotest_runner.zig",
+        build_async(target_neotest_build_file_path, test_runner_path,
             function()
                 future.set()
             end,
@@ -491,12 +482,6 @@ function M.results(spec, result, tree)
         end
     end
 
-    if spec.context.temp_neotest_runner_file_path then
-        local success = pcall(os.remove, spec.context.temp_neotest_runner_file_path)
-        if not success then
-            log.debug("Could not delete `temp_neotest_runner_file_path`", spec.context.temp_neotest_runner_file_path)
-        end
-    end
 
     local has_non_zero_exit, exit_message = handle_run_error(result, spec.context)
     if has_non_zero_exit then


### PR DESCRIPTION
This PR implements the following features related to https://github.com/lawrence-laz/neotest-zig/issues/9:

* Adds a configuration to customize the debugger adapter in the setup function

* Running the DAP strategy asynchronously builds the project using `nio.control.future` and native lua api (based on [rustacean implementation](https://github.com/mrcjkb/rustaceanvim/blob/2fa45427c01ded4d3ecca72e357f8a60fd8e46d4/lua/rustaceanvim/neotest/init.lua#L277) of the same feature)

~* Checks for the existence of `neotest_builder.zig` and `neotest_runner.zig` in the project directory and only copies the defaults if they don't exist (allows customization of the handlers and avoids deleting user files)~ discarded

* Displays  an error message on build errors with the `vim.notify` api.

* Selection of one output if the project emits more than one binary _should_ work on the lua side, but I haven't tested it. I don't quite understand how to get the `neotest_builder.zig` to generate multiple binaries