### PR TITLE
fixup: Backwards compatability with v0.12

### DIFF
--- a/zig/neotest_runner.zig
+++ b/zig/neotest_runner.zig
@@ -21,10 +21,28 @@ pub fn runnerLogFn(
 
     const prefix = "[" ++ comptime level.asText() ++ "] ";
 
-    std.debug.lockStdErr();
-    defer std.debug.unlockStdErr();
+    lockStderr();
+    defer unlockStdErr();
     const stderr = std.io.getStdErr().writer();
     nosuspend stderr.print(prefix ++ format ++ "\n", args) catch return;
+}
+
+fn lockStderr() void {
+    if (@hasDecl(std.debug, "lockStdErr")) {
+        std.debug.lockStdErr();
+    } else {
+        // v0.12.0 compatability
+        std.debug.getStderrMutex().lock();
+    }
+}
+
+fn unlockStdErr() void {
+    if (@hasDecl(std.debug, "unlockStdErr")) {
+        std.debug.unlockStdErr();
+    } else {
+        // v0.12.0 compatability
+        std.debug.getStderrMutex().unlock();
+    }
 }
 
 const STATUS_FAILED = "failed";


### PR DESCRIPTION
Zig v0.13 deprecated stderr mutex lock functions, instead it replaced it with use `lockStdErr` and `unlockStdErr`.
These functions, however, are not available in v0.12, so we need to check `std.debug` decls to be compatible with both v0.12 and v0.13.

Resolves #19