### PR TITLE
fix: Cannot run tests when git submodule contains `build.zig`

### DIFF
--- a/lua/neotest-zig/init.lua
+++ b/lua/neotest-zig/init.lua
@@ -388,7 +388,11 @@ function M.build_spec(args)
 
     local run_spec = nil
     local root_path = args.tree:root():data().path
-    local build_file_path = require("nio").fn.glob(root_path .. "**/build.zig")
+    local build_file_path_matches = vim.fn.glob(root_path .. "**/build.zig", false, true)
+    local build_file_path = ""
+    if (#build_file_path_matches > 0) then
+        build_file_path = build_file_path_matches[0]
+    end
     local use_build_file = build_file_path ~= nil and build_file_path ~= ""
 
     if use_build_file then


### PR DESCRIPTION
Glob function used to return all matches of `build.zig` in a newline separated list, which we incorrectly used as a single path.

Now glob pattern is requested to return a list of paths (by setting the third parameter to true) and we take only the first one. This still means you cannot run tests of submodules, only your root repo, as we only support a single `build.zig` file for now.

Resolves #24