### PR TITLE
Add windows support

### DIFF
--- a/zig/neotest_runner.zig
+++ b/zig/neotest_runner.zig
@@ -1,13 +1,10 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-const platforrm_stub = if (builtin.os.tag == .windows) struct {
-    const platform = @import("platform/windows/platform.zig");
-} else struct {
-    const platform = @import("platform/posix/platform.zig");
-};
-
-const platform = platforrm_stub.platform;
+const platform = if (builtin.os.tag == .windows)
+    @import("platform/windows/platform.zig")
+else
+    @import("platform/posix/platform.zig");
 
 pub const std_options: std.Options = .{
     .log_level = .debug,

--- a/zig/neotest_runner.zig
+++ b/zig/neotest_runner.zig
@@ -1,6 +1,14 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const platforrm_stub = if (builtin.os.tag == .windows) struct {
+    const platform = @import("platform/windows/platform.zig");
+} else struct {
+    const platform = @import("platform/posix/platform.zig");
+};
+
+const platform = platforrm_stub.platform;
+
 pub const std_options: std.Options = .{
     .log_level = .debug,
     .logFn = runnerLogFn,
@@ -98,12 +106,6 @@ fn getFuncSymbolInfo(allocator: std.mem.Allocator, func: *const fn () anyerror!v
     return symbol;
 }
 
-fn redirectStdErrToFile(absolute_file_path: []const u8) !void {
-    const file = try std.fs.createFileAbsolute(absolute_file_path, .{});
-    defer file.close();
-    try std.posix.dup2(file.handle, std.posix.STDERR_FILENO);
-}
-
 fn getZigLogLevelFromVimLogLevel(vim_log_level: u8) std.log.Level {
     return switch (vim_log_level) {
         0, 1 => std.log.Level.debug,
@@ -149,7 +151,8 @@ pub fn main() !void {
         const logs_file_name = try std.fmt.bufPrint(&hash_buffer, "{d}", .{hash_value});
         break :blk try std.fs.path.join(gpa.allocator(), &.{ logs_dir_path, logs_file_name });
     };
-    try redirectStdErrToFile(logs_file_path);
+    const logs_file = try platform.redirectStdErrToFile(logs_file_path);
+    defer logs_file.close();
 
     for (args, 0..) |arg, i| {
         log.debug("arg[{d}] = {s}", .{ i, arg });
@@ -186,7 +189,8 @@ pub fn main() !void {
     var timer = try std.time.Timer.start();
 
     for (builtin.test_functions) |test_function| {
-        try redirectStdErrToFile(logs_file_path);
+        const file = try platform.redirectStdErrToFile(logs_file_path);
+        defer file.close();
 
         if (processed_tests == input.len) {
             // All requested tests have been processed.
@@ -217,7 +221,8 @@ pub fn main() !void {
 
         log.debug("Running test {s}::{s}", .{ test_input.source_path, test_input.test_name });
 
-        try redirectStdErrToFile(test_input.output_path);
+        const test_input_file = try platform.redirectStdErrToFile(test_input.output_path);
+        defer test_input_file.close();
 
         processed_tests += 1;
 
@@ -322,7 +327,7 @@ pub fn main() !void {
         );
     }
 
-    try std.posix.dup2(std.posix.STDERR_FILENO, std.posix.STDERR_FILENO);
+    try platform.restoreStdErr();
 
     const test_results_json = try std.json.stringifyAlloc(gpa.allocator(), test_results.items, .{});
     const results_file = try std.fs.createFileAbsolute(results_file_path, .{});

--- a/zig/platform/posix/platform.zig
+++ b/zig/platform/posix/platform.zig
@@ -1,0 +1,11 @@
+const std = @import("std");
+
+pub fn redirectStdErrToFile(absolute_file_path: []const u8) !std.fs.File {
+    const file = try std.fs.createFileAbsolute(absolute_file_path, .{});
+    try std.posix.dup2(file.handle, std.posix.STDERR_FILENO);
+    return file;
+}
+
+pub fn restoreStdErr() !void {
+    try std.posix.dup2(std.posix.STDERR_FILENO, std.posix.STDERR_FILENO);
+}

--- a/zig/platform/windows/platform.zig
+++ b/zig/platform/windows/platform.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const windows = std.os.windows;
+
+extern "kernel32" fn SetStdHandle(nStdHandle: windows.DWORD, hHandle: windows.HANDLE) callconv(windows.WINAPI) windows.BOOL;
+
+fn setStdHandle(stdHandle: windows.DWORD, handle: windows.HANDLE) !void {
+    const result = SetStdHandle(stdHandle, handle);
+    if (result == 0) {
+        switch (windows.kernel32.GetLastError()) {
+            else => |err| return windows.unexpectedError(err),
+        }
+    }
+}
+
+var original_std_err_handle: windows.HANDLE = windows.INVALID_HANDLE_VALUE;
+
+pub fn redirectStdErrToFile(absolute_file_path: []const u8) !std.fs.File {
+    const file = try std.fs.createFileAbsolute(absolute_file_path, .{});
+    const handle: std.os.windows.HANDLE = file.handle;
+
+    if (original_std_err_handle == windows.INVALID_HANDLE_VALUE) {
+        original_std_err_handle = try windows.GetStdHandle(windows.STD_ERROR_HANDLE);
+    }
+
+    try setStdHandle(std.os.windows.STD_ERROR_HANDLE, handle);
+
+    return file;
+}
+
+pub fn restoreStdErr() !void {
+    try setStdHandle(std.os.windows.STD_ERROR_HANDLE, original_std_err_handle);
+}


### PR DESCRIPTION
Currently neotest-zig does not support windows.  This PR adds support for windows.

In order to support multiple platforms I have had to move the standard error redirection to a platform specific implementation file. The platform is chosen at comptime and imports the correct platform code to handle standard error redirection.

`redirectStdErrToFile` now returns a `std.fs.File` because in the windows code we cannot close the file immediately after redirecting std error to it. (at least from my testing and knowledge).

I have tested this in a windows environment, however I do not currently have a Linux environment at hand. So if someone can test on a Linux environment that would be awesome :). 
 
