### PR TITLE
Fix flatten deprecation

### DIFF
--- a/lua/neotest-zig/init.lua
+++ b/lua/neotest-zig/init.lua
@@ -42,7 +42,7 @@ end
 ---@param ... string Patterns to match e.g "*.zig"
 ---@return fun(path: string): string | nil
 function M.match_root_pattern(...)
-    local patterns = vim.tbl_flatten({ ... })
+    local patterns = vim.iter({ ... }):flatten():totable()
     return function(start_path)
         log.trace("Entered match_root_pattern with", start_path)
         local start_parents = Path:new(start_path):parents()

--- a/lua/neotest-zig/init.lua
+++ b/lua/neotest-zig/init.lua
@@ -35,6 +35,11 @@ function string.starts(String, Start)
     return string.sub(String, 1, string.len(Start)) == Start
 end
 
+local tbl_flatten = function(table)
+    return nio.fn.has("nvim-0.11") == 1 and vim.iter(table):flatten():totable()
+        or vim.tbl_flatten(table)
+end
+
 --- Create a function that will take directory and attempt to match the provided
 --- glob patterns against the contents of the directory.
 --- [!] This is a modified copy of a standard neotest function,
@@ -42,7 +47,7 @@ end
 ---@param ... string Patterns to match e.g "*.zig"
 ---@return fun(path: string): string | nil
 function M.match_root_pattern(...)
-    local patterns = vim.iter({ ... }):flatten():totable()
+    local patterns = tbl_flatten({ ... })
     return function(start_path)
         log.trace("Entered match_root_pattern with", start_path)
         local start_parents = Path:new(start_path):parents()


### PR DESCRIPTION
Nightly Neovim is stating this in checkhealth:

```
- WARNING vim.tbl_flatten is deprecated. Feature will be removed in Nvim 0.13
  - ADVICE:
    - use vim.iter(…):flatten():totable() instead.
    - stack traceback:
        /nix/store/7f1x0q2jggqznnpkv9ppl307d5p91svk-vim-pack-dir/pack/myNeovimPackages/start/neotest-zig/lua/neotest-zig/init.lua:45
        /nix/store/7f1x0q2jggqznnpkv9ppl307d5p91svk-vim-pack-dir/pack/myNeovimPackages/start/neotest-zig/lua/neotest-zig/init.lua:79
        [C]:-1
        /nix/store/ysncr3qa9xzqs4k70i1a0c96rqppv40n-init.lua:0

```

This commit applies the suggested fix.