### PR TITLE
Fixed compile errors introduced when switching to zig 0.15

### DIFF
--- a/zig/neotest_runner.zig
+++ b/zig/neotest_runner.zig
@@ -149,7 +149,7 @@ pub inline fn fuzz(
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    var test_results = std.ArrayList(TestResult).init(gpa.allocator());
+    var test_results = std.array_list.Managed(TestResult).init(gpa.allocator());
     var debug_info = try std.debug.getSelfDebugInfo();
 
     const args = try std.process.argsAlloc(gpa.allocator());

--- a/zig/neotest_runner.zig
+++ b/zig/neotest_runner.zig
@@ -28,11 +28,11 @@ pub fn runnerLogFn(
 
     lockStderr();
     defer unlockStdErr();
-    var stdout_buffer: [1024]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-    const stdout = &stdout_writer.interface;
-    stdout.print(prefix ++ format ++ "\n", args) catch return;
-    stdout.flush() catch return;
+    var stderr_buffer: [1024]u8 = undefined;
+    var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
+    const stderr = &stderr_writer.interface;
+    stderr.print(prefix ++ format ++ "\n", args) catch return;
+    stderr.flush() catch return;
 }
 
 fn lockStderr() void {

--- a/zig/neotest_runner.zig
+++ b/zig/neotest_runner.zig
@@ -301,9 +301,9 @@ pub fn main() !void {
                         break :blk;
                     };
                     defer output_file.close();
-                    var buffered_output_reader = std.io.bufferedReader(output_file.reader());
-                    const output_reader = buffered_output_reader.reader();
-                    first_output_line = output_reader.readUntilDelimiterAlloc(gpa.allocator(), '\n', 300) catch
+                    var buffer: [300]u8 = undefined;
+                    var output_reader = output_file.reader(&buffer);
+                    first_output_line = output_reader.interface.takeDelimiterExclusive('\n') catch
                         "Could not read output file.";
                 }
 

--- a/zig/neotest_runner.zig
+++ b/zig/neotest_runner.zig
@@ -28,8 +28,11 @@ pub fn runnerLogFn(
 
     lockStderr();
     defer unlockStdErr();
-    const stderr = std.io.getStdErr().writer();
-    nosuspend stderr.print(prefix ++ format ++ "\n", args) catch return;
+    var stdout_buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    const stdout = &stdout_writer.interface;
+    stdout.print(prefix ++ format ++ "\n", args) catch return;
+    stdout.flush() catch return;
 }
 
 fn lockStderr() void {

--- a/zig/neotest_runner.zig
+++ b/zig/neotest_runner.zig
@@ -364,8 +364,7 @@ pub fn main() !void {
     }
 
     try platform.restoreStdErr();
-
-    const test_results_json = try std.json.stringifyAlloc(gpa.allocator(), test_results.items, .{});
+    const test_results_json: []u8 = try std.fmt.allocPrint(gpa.allocator(), "{f}", .{std.json.fmt(test_results.items, .{})});
     const results_file = try std.fs.createFileAbsolute(results_file_path, .{});
     defer results_file.close();
     try results_file.writeAll(test_results_json);

--- a/zig/neotest_runner.zig
+++ b/zig/neotest_runner.zig
@@ -345,8 +345,8 @@ pub fn main() !void {
 
         const short_output = try std.fmt.allocPrint(
             gpa.allocator(),
-            "Test passed in {}",
-            .{std.fmt.fmtDuration(test_run_duration_in_ns)},
+            "Test passed in {D}",
+            .{test_run_duration_in_ns},
         );
 
         std.log.info("{s}", .{short_output});


### PR DESCRIPTION
Everything compiles now when running the test suite.

However, the test output is empty and there still seems to be a general issue that I cannot pinpoint. I tried to do an init project with zig 0.14.1 and zig 0.15.1 and when having a single failing test, it seems that 0.15.1 introduced some more whitespace in the test output. Does the plugin work by parsing the text output from the tests as a plain string? If this is the case, and if that is what causes the remaining issue, please let me know.

Example of failed test output:

## Zig 0.15.1 output: ##

❯ zig build test
test
└─ run test 1/2 passed, 1 failed
error: 'main.test.simple test' failed: expected 654, found 42
/usr/local/bin/zig-x86_64-linux-0.15.1/lib/std/testing.zig:110:17: 0x1035034 in expectEqualInner__anon_1949 (std.zig)
                return error.TestExpectedEqual;
                ^
/usr/local/bin/zig-x86_64-linux-0.15.1/lib/std/testing.zig:187:21: 0x1035110 in expectEqualInner__anon_1903 (std.zig)
                    try expectEqual(expected_payload, actual_payload);
                    ^
/home/stephan/projects/poc2/src/main.zig:15:5: 0x10353b9 in test.simple test (main.zig)
    try std.testing.expectEqual(@as(i32, 654), list.pop());
    ^
error: while executing test 'main.test.fuzz example', the following test command failed:
./.zig-cache/o/0f0b542836437cdf46eb1b4fd3192222/test --cache-dir=./.zig-cache --seed=0xdc7d436b --listen=-

Build Summary: 3/5 steps succeeded; 1 failed; 2/3 tests passed; 1 failed
test transitive failure
└─ run test 1/2 passed, 1 failed

error: the following build command failed with exit code 1:
.zig-cache/o/aff70ac9c878576356b8cbf4934231d9/build /usr/local/bin/zig-x86_64-linux-0.15.1/zig /usr/local/bin/zig-x86_64-linux-0.15.1/lib /home/stephan/projects/poc2 .zig-cache /home/stephan/.cache/zig --seed 0xdc7d436b -Z2597f23d636af66d test

## Zig 0.14.1 output: ##

❯ ../zig build test
test
└─ run test 2/3 passed, 1 failed
error: 'main.test.simple test' failed: expected 777, found 42
/home/stephan/Downloads/zig-x86_64-linux-0.14.1/lib/std/testing.zig:103:17: 0x104911d in expectEqualInner__anon_1903 (test)
                return error.TestExpectedEqual;
                ^
/home/stephan/Downloads/zig-x86_64-linux-0.14.1/lib/std/testing.zig:169:21: 0x1049258 in expectEqualInner__anon_1857 (test)
                    try expectEqual(expected_payload, actual_payload);
                    ^
/home/stephan/Downloads/zig-x86_64-linux-0.14.1/poc/src/main.zig:25:5: 0x104938c in test.simple test (test)
    try std.testing.expectEqual(@as(i32, 777), list.pop());
    ^
error: while executing test 'main.test.fuzz example', the following test command failed:
/home/stephan/Downloads/zig-x86_64-linux-0.14.1/poc/.zig-cache/o/ab3344cf1a7ace4f5b300a23073b6bff/test --seed=0x79643171 --cache-dir=/home/stephan/Downloads/zig-x86_64-linux-0.14.1/poc/.zig-cache --listen=-
Build Summary: 3/5 steps succeeded; 1 failed; 3/4 tests passed; 1 failed
test transitive failure
└─ run test 2/3 passed, 1 failed
error: the following build command failed with exit code 1:
/home/stephan/Downloads/zig-x86_64-linux-0.14.1/poc/.zig-cache/o/9a8684fde9dc0338af149f607d90ffc8/build /home/stephan/Downloads/zig-x86_64-linux-0.14.1/zig /home/stephan/Downloads/zig-x86_64-linux-0.14.1/lib /home/stephan/Downloads/zig-x86_64-linux-0.14.1/poc /home/stephan/Downloads/zig-x86_64-linux-0.14.1/poc/.zig-cache /home/stephan/.cache/zig --seed 0x79643171 -Z5000dcc1ff5e90d4 test

